### PR TITLE
Add windows support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,9 +30,19 @@ servers.each do |servers|
      srv.vm.network :forwarded_port, guest: port["guest"], host: port["host"], id: port["id"]
   end
 
-   srv.vm.provider :virtualbox do |v|
-        v.cpus = servers["cpu"]
-        v.memory = servers["ram"]
+  if !!File::ALT_SEPARATOR
+    srv.vm.provider :virtualbox do |v|
+      v.cpus = servers["cpu"]
+      v.memory = servers["ram"]
+    end
+  else
+    srv.vm.provider :hyperv do |hv|
+      hv.cpus = servers["cpu"]
+      hv.maxmemory = servers["ram"]
+      hv.vm_integration_services = {
+        guest_service_interface: true
+      }
+    end
   end
 
     srv.vm.synced_folder "./", "/home/vagrant/#{servers['name']}"

--- a/psake.ps1
+++ b/psake.ps1
@@ -1,0 +1,92 @@
+# TODO: Figure out logging
+# TODO: Figure out how (if at all) to make vagrant up parallel in the background
+#       One problem with this is the networking stack (have to manually select?)
+#       Another is having to provide password for shared drive.
+
+# Check your environment
+Task PreChecks {
+  $ServersYamlContent = Get-Content -Path "$PSScriptRoot/servers.yaml"
+  ForEach ($Box in 'bento/centos-7.5','bento/ubuntu-16.04') {
+    If ($ServersYamlContent -match $Box) {
+      Write-Verbose "$Box is the current base image you are using"
+      If ((vagrant box list | Where-Object -FilterScript {$_ -match $Box})) {
+        Write-Verbose "You have the base image already locally downloaded"
+      } Else {
+        Write-Warning "The base image needs to be downloaded."
+      }
+    }
+  }
+}
+
+# Build your cluster
+Task Build {
+  Write-Verbose "Deploying Kubernetes controller"
+  vagrant up kube-master
+  vagrant up kube-node-01
+  vagrant up kube-node-02
+  Write-Verbose 'Deploying worker nodes'
+  Write-Verbose 'You can check their progress with "kubectl get nodes"'
+}
+
+# Spin up LB as a VM since it won't work as a container
+Task LoadBalancer {
+  Write-Verbose 'Can not install the LB on Mac OS due to networking limitation on Docker for mac'
+  Write-Verbose 'Add "172.17.10.214 kubernetes" to /etc/hosts as a work around'
+  Write-Verbose 'Bringing up vagrant load balancer'
+  vagrant up lb
+}
+
+# Build HA Kubernetes Controllers
+Task HAControllers -Depends LoadBalancer {
+  Write-Verbose 'Deploying Kubernetes HA controllers'
+  vagrant up kube-master
+  vagrant up kube-replica-master-01
+  vagrant up kube-replica-master-02
+  Write-Verbose 'You can access your cluster with "kubectl get nodes"'
+}
+
+# Verify kubectl is installed
+Task PostChecks {
+  If (Get-Command 'kubectl' -CommandType Application -ErrorAction SilentlyContinue) {
+    Write-Verbose 'Kubectl is installed'
+  } Else {
+    Throw 'Kubectl is not installed, please install using the following URL: https://kubernetes.io/docs/tasks/tools/install-kubectl/'
+  }
+}
+
+# Set up local kubectl
+Task Kubectl -Depends PostChecks{
+  $FolderPath = "$PSScriptRoot/.kube/"
+  If (!(Test-Path -Path $FolderPath)) {
+    New-Item -Path $FolderPath -ItemType Directory -Force
+  }
+  vagrant ssh kube-master -c 'sudo cp /etc/kubernetes/admin.conf ~/kube-master/.kube/admin.conf && sudo chown vagrant:vagrant ~/kube-master/.kube/admin.conf > /dev/null 2>&1'
+  Write-Verbose 'Configuring local Kubectl'
+  $env:KUBECONFIG = "$PSScriptRoot/.kube/admin.conf" -replace '\\','/'
+}
+
+# Adds nodes to controllers after 'ClusterUpHA
+Task AddNodes {
+  Write-Verbose "Deploying worker nodes"
+  vagrant up kube-node-01
+  vagrant up kube-node 02
+}
+
+# Post tasks for ClusterUp
+Task PostTasks {
+  $Content = (Get-Content -Path "$PSScriptRoot/.kube/admin.conf") -replace '172.17.10.101:6443', 'kubernetes:6443'
+  Set-Content -Path "$PSScriptRoot/.kube/admin.conf" -Value $Content -Encoding UTF8
+}
+
+# Delete your kubernetes cluster
+Task CleanUp {
+  Write-Verbose "Deleting your Kubernetes cluster"
+  vagrant destroy --force
+  If (Test-Path -Path "$PSScriptRoot/.log/") {
+    Remove-Item -Path "$PSScriptRoot/.log/*.log" -Force
+  }
+}
+
+Task ClusterUp    -depends PreChecks,Build,Kubectl
+Task ClusterUpHA  -depends PreChecks,HAControllers,Kubectl,PostTasks
+Task ClusterUpAll -depends PreChecks,HAControllers,AddNodes,Kubectl,PostTasks

--- a/servers.yaml
+++ b/servers.yaml
@@ -12,6 +12,7 @@
       - { shell: 'ufw disable && swapoff -a' }
       - { shell: 'wget https://apt.puppetlabs.com/puppet6-release-xenial.deb && sudo dpkg -i puppet6-release-xenial.deb'}
       - { shell: 'apt-get update -y && apt-get install vim git puppet-agent rubygems ruby-dev -y' }
+      - { shell: 'gem install cri --version 2.15.6'}
       - { shell: 'gem install r10k'}
       - { shell: 'cp /home/vagrant/kube-master/Puppetfile /tmp && cd /tmp && r10k puppetfile install --verbose' }
       - { shell: 'cp /home/vagrant/kube-master/modules/* -R /tmp/modules || true'}
@@ -28,6 +29,7 @@
       - { shell: 'ufw disable && swapoff -a' }
       - { shell: 'wget https://apt.puppetlabs.com/puppet6-release-xenial.deb && sudo dpkg -i puppet6-release-xenial.deb'}
       - { shell: 'apt-get update -y && apt-get install vim git puppet-agent rubygems ruby-dev -y' }
+      - { shell: 'gem install cri --version 2.15.6'}
       - { shell: 'gem install r10k'}
       - { shell: 'cp /home/vagrant/kube-replica-master-01/Puppetfile /tmp && cd /tmp && r10k puppetfile install --verbose' }
       - { shell: 'cp /home/vagrant/kube-replica-master-01/modules/* -R /tmp/modules || true'}
@@ -44,6 +46,7 @@
       - { shell: 'ufw disable && swapoff -a' }
       - { shell: 'wget https://apt.puppetlabs.com/puppet6-release-xenial.deb && sudo dpkg -i puppet6-release-xenial.deb'}
       - { shell: 'apt-get update -y && apt-get install vim git puppet-agent rubygems ruby-dev -y' }
+      - { shell: 'gem install cri --version 2.15.6'}
       - { shell: 'gem install r10k'}
       - { shell: 'cp /home/vagrant/kube-replica-master-02/Puppetfile /tmp && cd /tmp && r10k puppetfile install --verbose' }
       - { shell: 'cp /home/vagrant/kube-replica-master-02/modules/* -R /tmp/modules || true'}
@@ -60,6 +63,7 @@
       - { shell: 'ufw disable && swapoff -a' }
       - { shell: 'wget https://apt.puppetlabs.com/puppet6-release-xenial.deb && sudo dpkg -i puppet6-release-xenial.deb'}
       - { shell: 'apt-get update -y && apt-get install vim git puppet-agent rubygems ruby-dev -y' }
+      - { shell: 'gem install cri --version 2.15.6'}
       - { shell: 'gem install r10k'}
       - { shell: 'cp /home/vagrant/kube-node-01/Puppetfile /tmp && cd /tmp && r10k puppetfile install --verbose' }
       - { shell: 'cp /home/vagrant/kube-node-01/modules/* -R /tmp/modules || true'}
@@ -76,6 +80,7 @@
       - { shell: 'ufw disable && swapoff -a' }
       - { shell: 'wget https://apt.puppetlabs.com/puppet6-release-xenial.deb && sudo dpkg -i puppet6-release-xenial.deb'}
       - { shell: 'apt-get update -y && apt-get install vim git puppet-agent rubygems ruby-dev -y' }
+      - { shell: 'gem install cri --version 2.15.6'}
       - { shell: 'gem install r10k'}
       - { shell: 'cp /home/vagrant/kube-node-02/Puppetfile /tmp && cd /tmp && r10k puppetfile install --verbose' }
       - { shell: 'cp /home/vagrant/kube-node-02/modules/* -R /tmp/modules || true'}


### PR DESCRIPTION
This set of commits makes a minor (temporary) fix to the vagrant provisioning and adds initial support for using KREAM to set up an environment from a windows client.

It presumes you have Hyper-V and Psake installed (for now).

It does not include a docs change yet.