### PR TITLE
(maint) - add support for kubernetes v1.25+

### DIFF
--- a/hieradata/Debian.yaml
+++ b/hieradata/Debian.yaml
@@ -1,7 +1,9 @@
 
-kubernetes::kubernetes_version: 1.13.5
-kubernetes::kubernetes_package_version: 1.13.5-00
+kubernetes::kubernetes_version: 1.26.0
+kubernetes::kubernetes_package_version: 1.26.0-00
 kubernetes::container_runtime: docker
+# remove line below if using kubernetes versions < 1.25
+kubernetes::image_repository: registry.k8s.io
 kubernetes::cni_network_provider: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 kubernetes::cni_pod_cidr: 10.244.0.0/16
 kubernetes::etcd_initial_cluster: kube-master=https://192.168.56.101:2380

--- a/hieradata/RedHat.yaml
+++ b/hieradata/RedHat.yaml
@@ -1,6 +1,11 @@
-kubernetes::kubernetes_version: 1.23.0
-kubernetes::kubernetes_package_version: 1.23.0
+kubernetes::kubernetes_version: 1.26.0
+kubernetes::kubernetes_package_version: 1.26.0
 kubernetes::container_runtime: cri_containerd
+# update containerd version below based on kubenetes version specified above 
+# refer to https://containerd.io/releases/#kubernetes-support for more info
+kubernetes::containerd_version: 1.6.0
+# remove line below if using kubernetes versions < 1.25
+kubernetes::image_repository: registry.k8s.io
 kubernetes::cni_network_provider: https://docs.projectcalico.org/manifests/calico-typha.yaml
 kubernetes::cni_pod_cidr: 10.244.0.0/16
 kubernetes::etcd_initial_cluster: kube-master=https://192.168.56.101:2380


### PR DESCRIPTION
Prior to this PR, kream was unable to spin up clusters with kubernetes v1.25 or above.
This was due to the deprecation of certain containerd versions and the updating of the link to kubernetes container registry.

This PR aims to add two hiera variables ('kubernetes::containerd_version', 'kubernetes::image_repository') that can be adjusted so that kream can spin up clusters with kubernetes versions that are both above and below v1.25.